### PR TITLE
Use ephemeral BLE connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Python application that monitors Google Meet tabs in Safari and controls an LE
 - Controls LED strip via Bluetooth
 - Non-intrusive monitoring (doesn't force Safari to open)
 - Background operation with proper logging
+- Temporary BLE connection per command
 - Easy start/stop scripts
 
 ## Open Source
@@ -100,13 +101,14 @@ tail -f meet_monitor.log
 ## How It Works
 
 1. The monitor checks Safari tabs every second
-2. If a Google Meet tab is found:
+2. Each LED action opens a short BLE connection to send the command
+3. If a Google Meet tab is found:
    - LED turns red
    - Status is logged
-3. If no Meet tabs are found:
+4. If no Meet tabs are found:
    - LED returns to pleasant blue
    - Status is logged
-4. All events are logged with timestamps
+5. All events are logged with timestamps
 
 ## Troubleshooting
 
@@ -131,8 +133,8 @@ tail -f meet_monitor.log
 
 ### Logs
 
-Check `meet_monitor.log` for detailed information about:
-- Connection status
+- Check `meet_monitor.log` for detailed information about:
+- BLE operations
 - Meet detection
 - LED color changes
 - Any errors or warnings

--- a/led_controller.py
+++ b/led_controller.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
-from bleak import BleakClient, BleakScanner
+from bleak import BleakClient
 
 class LEDController:
     def __init__(self, device_address="61C008D6-5838-2D1B-F300-86F1AAFB172B"):
         self.device_address = device_address
-        self.client = None
         self.notification_characteristic = "0000fff4-0000-1000-8000-00805f9b34fb"
         self.write_characteristic = "0000fff3-0000-1000-8000-00805f9b34fb"
         
@@ -13,84 +12,49 @@ class LEDController:
         self.TURN_ON_CMD = bytearray.fromhex("7e 07 04 ff 00 01 02 01 ef")
         self.TURN_OFF_CMD = bytearray.fromhex("7e 07 04 00 00 00 02 01 ef")
 
-    async def connect(self):
-        """Connects to the LED device"""
-        try:
-            self.client = BleakClient(self.device_address)
-            await self.client.connect()
-            logging.info(f"Connected to LED device: {self.device_address}")
-            return True
-        except Exception as e:
-            logging.error(f"Connection error: {str(e)}")
-            return False
-
-    async def disconnect(self):
-        """Disconnects from the LED device"""
-        if self.client and self.client.is_connected:
-            await self.client.disconnect()
-            logging.info("Disconnected from LED device")
 
     async def turn_on(self):
         """Turns on the LED strip"""
-        if not self.client or not self.client.is_connected:
-            logging.warning("Not connected to device")
-            return False
-        
         try:
-            await self.client.write_gatt_char(self.write_characteristic, self.TURN_ON_CMD)
-            logging.info("LED strip turned on")
-            return True
+            async with BleakClient(self.device_address) as client:
+                await client.write_gatt_char(self.write_characteristic, self.TURN_ON_CMD)
+                logging.info("LED strip turned on")
+                return True
         except Exception as e:
             logging.error(f"Error turning on: {str(e)}")
             return False
 
     async def turn_off(self):
         """Turns off the LED strip"""
-        if not self.client or not self.client.is_connected:
-            logging.warning("Not connected to device")
-            return False
-        
         try:
-            await self.client.write_gatt_char(self.write_characteristic, self.TURN_OFF_CMD)
-            logging.info("LED strip turned off")
-            return True
+            async with BleakClient(self.device_address) as client:
+                await client.write_gatt_char(self.write_characteristic, self.TURN_OFF_CMD)
+                logging.info("LED strip turned off")
+                return True
         except Exception as e:
             logging.error(f"Error turning off: {str(e)}")
             return False
 
     async def set_color(self, r, g, b):
-        """
-        Sets the color of the LED strip
-        :param r: Red value (0-255)
-        :param g: Green value (0-255)
-        :param b: Blue value (0-255)
-        """
-        if not self.client or not self.client.is_connected:
-            logging.warning("Not connected to device")
-            return False
-        
+        """Sets the color of the LED strip"""
         try:
-            color_data = bytearray.fromhex("7e 07 05 03 ff 00 00 10 ef")
-            color_data[4] = r
-            color_data[5] = g
-            color_data[6] = b
-            
-            await self.client.write_gatt_char(self.write_characteristic, color_data)
-            logging.info(f"Color set: RGB({r}, {g}, {b})")
-            await asyncio.sleep(0.1)
-            return True
+            async with BleakClient(self.device_address) as client:
+                color_data = bytearray.fromhex("7e 07 05 03 ff 00 00 10 ef")
+                color_data[4] = r
+                color_data[5] = g
+                color_data[6] = b
+                await client.write_gatt_char(self.write_characteristic, color_data)
+                logging.info(f"Color set: RGB({r}, {g}, {b})")
+                await asyncio.sleep(0.1)
+                return True
         except Exception as e:
             logging.error(f"Error setting color: {str(e)}")
             return False
 
 async def main():
     controller = LEDController()
-    if await controller.connect():
-        try:
-            await controller.set_color(255, 0, 0)
-            await asyncio.sleep(2)
-        finally:
-            await controller.disconnect()
+    await controller.set_color(255, 0, 0)
+    await asyncio.sleep(2)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/meet_led_monitor.py
+++ b/meet_led_monitor.py
@@ -44,16 +44,13 @@ class MeetLEDMonitor:
         Main monitoring loop
         :param check_interval: Time between checks in seconds
         """
-        if await self.led.connect():
-            try:
-                logging.info("Starting Meet LED monitor...")
-                while True:
-                    await self.update_led_color()
-                    await asyncio.sleep(check_interval)
-            except KeyboardInterrupt:
-                logging.info("Stopping monitor...")
-            finally:
-                await self.led.disconnect()
+        try:
+            logging.info("Starting Meet LED monitor...")
+            while True:
+                await self.update_led_color()
+                await asyncio.sleep(check_interval)
+        except KeyboardInterrupt:
+            logging.info("Stopping monitor...")
 
 async def main():
     monitor = MeetLEDMonitor()


### PR DESCRIPTION
## Summary
- refactor LED controller to use temporary `BleakClient` context
- update monitor to rely on short connections
- document the new behavior in README

## Testing
- `python3 -m py_compile ble_scan.py led_controller.py meet_led_monitor.py safari_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_684847781cd883289f498e201e179679